### PR TITLE
Rewriting modulo alpha-equivalence

### DIFF
--- a/heifer
+++ b/heifer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export DEBUG='5; h rewrite_rooted; h rewrite_all; h unify; h infer_types_pi'
+# export DEBUG='5; h rewrite_rooted; h rewrite_all; h unify; h infer_types_pi'
 
 set -x
 dune exec main/hip.exe -- "$@"

--- a/lib/hipcore_typed/syntax.ml
+++ b/lib/hipcore_typed/syntax.ml
@@ -37,6 +37,7 @@ let eq x y =
 
 let v ?(typ = TVar (Hipcore.Variables.fresh_variable ~v:"v" ())) x = {term_desc = Var x; term_type = typ}
 let var = v
+let var_any x = {term_desc = Var x; term_type = Any}
 let num n = {term_desc = Const (Num n); term_type = Int}
 let tnot t = {term_desc = TNot t; term_type = Bool}
 let points_to x y = PointsTo (x, y)

--- a/lib/hipprover/rewriting.ml
+++ b/lib/hipprover/rewriting.ml
@@ -1146,6 +1146,7 @@ let%expect_test "rewriting" =
 
 let%expect_test "unify modulo alpha-equivalence" =
   let open Syntax in
+  Variables.reset_counter 0;
   let test a b =
     let st = UF.new_store () in
     let a1 = to_unifiable st a in
@@ -1163,13 +1164,20 @@ let%expect_test "unify modulo alpha-equivalence" =
     let a = Staged (Bind (("x", Any), res_eq_1, ens ~p:(eq (var_any "res") (var_any "x")) ())) in
     let b = Staged (Bind (("y", Any), res_eq_1, ens ~p:(eq (var_any "res") (var_any "y")) ())) in
     test a b;
-    [%expect{| let x4 = (ens res=1) in (ens res=x4) |}]
+    [%expect{| let x0 = (ens res=1) in (ens res=x0) |}]
+  in
+  let () =
+    let a = Staged (Exists (("x", Any), ens ~p:(eq (var_any "res") (var_any "x")) ())) in
+    let b = Staged (Exists (("y", Any), ens ~p:(eq (var_any "res") (var_any "y")) ())) in
+    test a b;
+    [%expect{| ex x1. (ens res=x1) |}]
   in
   ()
 
 let%expect_test "rewriting modulo alpha-equivalence" =
   let open Syntax in
   let open Rules in
+  Variables.reset_counter 0;
   let test_with_printer pp_rule pp_ut rule ut =
     let new_ut = rewrite_all rule ut in
     Format.printf "rewrite %s@." (pp_ut ut);

--- a/lib/hipprover/rewriting.ml
+++ b/lib/hipprover/rewriting.ml
@@ -379,20 +379,6 @@ let to_unifiable st f : unifiable =
       method! visit_binder () (x, t) =
         let b, e = super#visit_binder () (x, t) in
         if is_uvar_name x then ((x, t), SMap.add x (mk_entry ()) e) else (b, e)
-
-
-      (* binders *)
-      (* method! visit_Bind () x f1 f2 =
-        let v1, e = super#visit_Bind () x f1 f2 in
-        if binder_is_uvar x then (v1, SMap.add (ident_of_binder x) (UF.make st None) e) else (v1, e)
-
-      method! visit_Exists () x f =
-        let v1, e = super#visit_Exists () x f in
-        if binder_is_uvar x then (v1, SMap.add (ident_of_binder x) (UF.make st None) e) else (v1, e)
-
-      method! visit_ForAll () x f =
-        let v1, e = super#visit_ForAll () x f in
-        if binder_is_uvar x then (v1, SMap.add (ident_of_binder x) (UF.make st None) e) else (v1, e) *)
     end
   in
   match f with
@@ -889,9 +875,7 @@ let rewrite_rooted rule target =
     let inst_rhs =
       match rule.rhs with
       | `Replace rhs -> subst_uvars s (rhs, e)
-      | `Dynamic f ->
-        let mapping x = UF.get s (SMap.find (var_prefix ^ x) e) |> Option.get in
-        f mapping
+      | `Dynamic f -> f (fun x -> instantiate_uvar s e (var_prefix ^ x))
     in
     inst_rhs
   else Some target

--- a/lib/utils/options.ml
+++ b/lib/utils/options.ml
@@ -2,3 +2,9 @@ let rec concat_option = function
   | [] -> []
   | None :: os -> concat_option os
   | Some x :: os -> x :: concat_option os
+
+
+module Syntax = struct
+  let ( let* ) = Option.bind
+  let ( let+ ) a f = Option.map f a
+end

--- a/lib/utils/options.mli
+++ b/lib/utils/options.mli
@@ -1,1 +1,6 @@
 val concat_option : 'a option list -> 'a list
+
+module Syntax : sig
+  val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option
+  val ( let+ ) : 'a option -> ('a -> 'b) -> 'b option
+end

--- a/test/reset_shift_progs/append.ml
+++ b/test/reset_shift_progs/append.ml
@@ -17,7 +17,7 @@ let rec append_cps xs ys k =
 
 [%%lemma{|
   delim_to_cps(xs, ys) =
-    let v23 = rs(append_delim_aux(xs)) in v23(ys) ==>
+    let k = rs(append_delim_aux(xs)) in k(ys) ==>
     let k = (ens res = fun (r) -> (ens res = r)) in append_cps(xs, ys, k)
 |}]
 

--- a/test/reset_shift_progs/times.ml
+++ b/test/reset_shift_progs/times.ml
@@ -10,7 +10,7 @@ let rec times2_aux xs =
 
 [%%lemma{|
   times2_lemma(x, xs) =
-    rs(let v60 = times2_aux(xs) in ens res = x *. v60) ==>
+    rs(let r = times2_aux(xs) in ens res = x *. r) ==>
     ens res = x *. times(xs) |}]
 
 let [@spec "ens res = times(xs)"] times2 xs =


### PR DESCRIPTION
This resolves issue #37. Issue #30 and #48 will also be considered.

The current progress:
- Alpha-equivalence is considered for `exists`, `forall` and `bind`.
- Alpha-equivalence is will not be considered for lambda term at the moment, due to the difficulty of implementation (a list of arguments instead of a single argument), and also as lambda term does not appear often in the LHS.

New problems found:
- Unfolding need to be done with dedicated function, instead of rewriting rule. This is elaborated in #50.
- Unification of types (with type variables) need to be reviewed again #51.