### PR TITLE
Account for types of higher-order functions during typechecking

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -83,6 +83,12 @@ View log output by setting `DEBUG=n`.
 | 1    | Explanations, for users              |
 | >= 2 | More and more detail, for developers |
 
+Several built-in filtering options are available; these can be set by setting `DEBUG='n; <option 1>; <option 2>; ...`. See the documentation of `debug.mli` for more details.
+
+Some helpful options:
+- `h rewrite_*` filters out all logs related to the rewrite libraries (which appear at level 5 and above).
+- `h unify_types; h infer_types*` filters out all logs related to type inference (which appear at level 10 and above).
+
 Set `FILE=1` to direct logs to an org-mode file, which is useful for structural navigation.
 
 Set `CTF=1` to produce a trace file that can be viewed with [Perfetto](https://ui.perfetto.dev/), queried with [PerfettoSQL](https://perfetto.dev/docs/quickstart/trace-analysis), etc. This is useful for profiling.

--- a/lib/hipcore/types.ml
+++ b/lib/hipcore/types.ml
@@ -69,6 +69,8 @@ let rec params_of_arrow_type t =
       t1 :: params, result
   | _ -> [], t
 
+let arrow_type_of_params params result = List.fold_right (fun typ acc -> Arrow (typ, acc)) params result
+
 let concrete_types = [Unit; Int; Bool; Lamb]
 
 let new_type_var : ?name:string -> unit -> typ =

--- a/lib/hipcore_typed/Pretty.ml
+++ b/lib/hipcore_typed/Pretty.ml
@@ -303,6 +303,9 @@ module With_types = struct
     | PAlias (p, s) -> Format.sprintf "(%s) as %s" (string_of_pattern p) s
     in
     Format.sprintf "%s : %s" desc (string_of_type p.pattern_type)
+
+  let string_of_pred ({p_name; p_params; p_body; _}) =
+    Format.asprintf "%s(%s) == %s" p_name (p_params |> List.map string_of_binder |> String.concat ", ") (string_of_staged_spec p_body)
 end
 
 (** formatters, more fit for external output *)

--- a/lib/hiplib/hiplib.ml
+++ b/lib/hiplib/hiplib.ml
@@ -343,10 +343,11 @@ let process_intermediates (it : Typedhip.intermediate) prog : binder list * core
       [m_name, function_type], prog
 
 let process_ocaml_structure (items: Ocaml_common.Typedtree.structure) : unit =
-  let process_ocaml_item (bound_names, prog) item =
+  let untyped_items = Untypeast.untype_structure items in
+  let process_ocaml_item (bound_names, prog) (item_untyped, item) =
     let intermediate = 
       let@ _ = Debug.(span (fun _ -> 
-        debug ~at:3 ~title:"parsing next ocaml structure item" ""
+        debug ~at:3 ~title:"parsing next ocaml structure item" "%s" (Pprintast.string_of_structure [item_untyped])
       ))
       in
       Ocamlfrontend.Core_lang_typed.transform_str bound_names item
@@ -358,7 +359,7 @@ let process_ocaml_structure (items: Ocaml_common.Typedtree.structure) : unit =
     | None ->
         bound_names, prog
   in
-  ignore (List.fold_left process_ocaml_item ([], empty_program) items.str_items)
+  ignore (List.fold_left process_ocaml_item ([], empty_program) (List.combine untyped_items items.str_items))
 
 let run_ocaml_string s =
   (** Parse and typecheck the code, before converting it into a core language program.

--- a/lib/hiplib/hiplib.ml
+++ b/lib/hiplib/hiplib.ml
@@ -344,7 +344,14 @@ let process_intermediates (it : Typedhip.intermediate) prog : binder list * core
 
 let process_ocaml_structure (items: Ocaml_common.Typedtree.structure) : unit =
   let process_ocaml_item (bound_names, prog) item =
-    match Ocamlfrontend.Core_lang_typed.transform_str bound_names item with
+    let intermediate = 
+      let@ _ = Debug.(span (fun _ -> 
+        debug ~at:3 ~title:"parsing next ocaml structure item" ""
+      ))
+      in
+      Ocamlfrontend.Core_lang_typed.transform_str bound_names item
+    in
+    match intermediate with
     | Some it ->
         let new_bound, prog = process_intermediates it prog in
         new_bound @ bound_names, prog

--- a/lib/hipprover/infer_types.ml
+++ b/lib/hipprover/infer_types.ml
@@ -36,7 +36,7 @@ let () =
 
 let rec unify_types t1 t2 : unit using_env =
   fun env ->
-    debug ~at:5 ~title:"unify" "%s ~ %s" (string_of_type t1) (string_of_type t2);
+    debug ~at:10 ~title:"unify_types" "%s ~ %s" (string_of_type t1) (string_of_type t2);
     match TEnv.(simplify env.equalities t1, simplify env.equalities t2) with
     (* case where one of t1, t2 is a type variable: *)
     | TVar var_name as var, simp | simp, (TVar var_name as var) -> 
@@ -272,7 +272,7 @@ and infer_types_constant ?(hint : typ option) const : typ =
 and infer_types_term ?(hint : typ option) term : term using_env =
   let@ _ =
     span_env (fun r ->
-        debug ~at:5 ~title:"infer_types" "%s : %s -| %s" (string_of_term term)
+        debug ~at:10 ~title:"infer_types" "%s : %s -| %s" (string_of_term term)
           (string_of_result string_of_term (State.Debug.presult_value r))
           (string_of_result string_of_abs_env (State.Debug.presult_state r)))
   in
@@ -382,7 +382,7 @@ and infer_types_constructor_like :
 and infer_types_pi pi : pi using_env =
   let@ _ =
        span_env (fun r ->
-           debug ~at:5 ~title:"infer_types_pi" "%s -| %s" (string_of_pi pi)
+           debug ~at:10 ~title:"infer_types_pi" "%s -| %s" (string_of_pi pi)
              (string_of_result string_of_abs_env (State.Debug.presult_state r)))
      in
   match pi with
@@ -436,6 +436,11 @@ and infer_types_state (p, k) : state using_env =
   is the type, if any, returned by the computations satisfying this spec. *)
 
 and infer_types_staged_spec ss : (staged_spec * typ option) using_env =
+  let@ _ =
+       span_env (fun r ->
+           debug ~at:10 ~title:"infer_types_staged_spec" "%s -| %s" (string_of_staged_spec ss)
+             (string_of_result string_of_abs_env (State.Debug.presult_state r)))
+     in
   let type_of_result_of_pi p =
     let pi_free_vars = Subst.(types_of_free_vars Sctx_pure p) in
     SMap.find_opt "res" pi_free_vars |> Option.join

--- a/lib/hipprover/infer_types.ml
+++ b/lib/hipprover/infer_types.ml
@@ -272,7 +272,7 @@ and infer_types_constant ?(hint : typ option) const : typ =
 and infer_types_term ?(hint : typ option) term : term using_env =
   let@ _ =
     span_env (fun r ->
-        debug ~at:10 ~title:"infer_types" "%s : %s -| %s" (string_of_term term)
+        debug ~at:10 ~title:"infer_types_term" "%s : %s -| %s" (string_of_term term)
           (string_of_result string_of_term (State.Debug.presult_value r))
           (string_of_result string_of_abs_env (State.Debug.presult_state r)))
   in

--- a/test/basic.t/run.t
+++ b/test/basic.t/run.t
@@ -29,8 +29,8 @@
                 if_let: true
                   foo1: true
                   foo2: true
-                  goo1: false
-                  goo2: false
+                  goo1: true
+                  goo2: true
            call_f_in_g: true
               call_ret: true
      test_non_rec_pred: true
@@ -38,15 +38,14 @@
   [1]
 
   $ check test_ho.ml
-            test1_true: false
+            test1_true: true
             test2_true: false
            test5_false: false (expected)
-            test3_true: false
-            test4_true: false
-            test6_true: false
+            test3_true: true
+            test4_true: true
+            test6_true: true
            test7_false: false (expected)
-          compose_true: false
-   compose_exists_true: false
+          compose_true: true
   [1]
 
   $ check test_lists.ml

--- a/test/basic.t/test_ho.ml
+++ b/test/basic.t/test_ho.ml
@@ -1,6 +1,6 @@
 
 let test1_true f
-  (*@ ex r. f(1, r); ens emp/\res=r @*) =
+  (*@ let r = f(1) in ens emp/\res=r@*) =
   f 1
 
 (* disabled because this now raises an error due to g being undefined in the spec *)
@@ -9,42 +9,43 @@ let test1_true f
 (*   f 1 *)
 
 let test2_true f g
-  (*@ ex r s. f(1, r); g(1, s); ens emp/\res=s @*) =
+  (*@ let r = f(1) in let s = g(1) in ens emp/\res=s @*) =
   f 1;
   g 1
 
 let test5_false f g
-  (*@ ex r s. f(1, r); g(2, s); ens emp/\res=s @*) =
+  (*@ let r = f(1) in let s = g(2) in ens emp /\ res=s @*) =
   f 1;
   g 1
 
 let test3_true f g
-  (*@ ex r s. f(1, r); g(r, s); ens emp/\res=s @*) =
+  (*@ let r = f(1) in let s = g(r) in ens emp /\ res = s @*) =
   let x = f 1 in
   g x
 
 let rec test4_true ()
-  (*@ ex r. test4_true((), r); ens emp/\res=r @*) =
+  (*@ let r = test4_true(()) in ens emp /\ res=r @*) =
   test4_true ()
 
 let rec test6_true b n
-  (*@ ens emp/\res=0 \/ ex r. test6_true(b, n-1, r); ens emp/\res=r @*) =
+  (*@ ens emp/\res = 0 \/ let r = test6_true(b, n-1) in ens emp /\ res=r @*) =
   if b then 0 else test6_true b (n - 1)
 (* this is already unfolded *)
 
 let rec test7_false b n
-  (*@ ex r. test7_false(b, n, r); ens emp/\res=r @*) =
+  (*@ let r = test7_false(b, n) in ens emp/\res = r @*) =
   if b then 0 else test7_false b (n - 1)
 (* need explicit unfolding *)
 
 let compose_true f g x
 (*@
-  ex r_g. g(x, r_g);
-  ex r_f. f(r_g, r_f);
-  ens  emp/\res=r_f
+  let r_g = g(x) in
+  let r_f = f(r_g) in
+  ens emp/\res = r_f
 @*)
 = f (g x)
 
+(* redundant due to examples being ported to use binds to invoke higher-order functions:
 let compose_exists_true f g x
 (*@
   ex r_g r_f.
@@ -53,5 +54,6 @@ let compose_exists_true f g x
   ens  emp/\res=r_f
 @*)
 = f (g x)
+*)
 (* the positions of existentials matter and have to match the implementation, due to the way proving is done at each stage.
 we optimize the positions of existentials automatically so this passes. *)

--- a/test/basic.t/test_new_entail.ml
+++ b/test/basic.t/test_new_entail.ml
@@ -170,11 +170,11 @@ let foo1 xs = 1
 let foo2 xs (*@ ens res=1 @*) = 1
 
 let goo1 xs
-(*@ ex t. foo1(xs, t); ens res=t @*)
+(*@ let t = foo1(xs) in ens res=t @*)
 = foo1 xs
 
 let goo2 xs
-(*@ ex t. foo2(xs, t); ens res=t @*)
+(*@ let t = foo2(xs) in ens res=t @*)
 = foo2 xs
 
 let call_f_in_g ()
@@ -183,7 +183,7 @@ let call_f_in_g ()
   let f x = x in
   f 5
 
-let call_ret f (* ex v; f(100,v); ens res=v *) =
+let call_ret f (*@ let v = f(100) in ens res=v @*) =
   f 100
 
 let test_non_rec_pred ()


### PR DESCRIPTION
Take the argument and return types of higher-order function calls into account during type checking. This deprecates the use of higher-order function names as predicates for results (i.e. `f(a, b, ..., res)` ) in staged specifications, instead preferring to use binds (see #52 for related work).

This addresses the instance of #51 I noticed during debugging, but unifying types of terms during rewriting remains disabled (although re-enabling unification of term types does not seem to break anything at the moment).

Also adds some tweaks to the debug spans to resolve #47.